### PR TITLE
Fix GitHub Actions workflow to deploy to EC2 instances after pushing to ECR

### DIFF
--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -1,4 +1,6 @@
 name: Deploy to ECR and EC2
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -1,0 +1,140 @@
+name: Deploy to ECR and EC2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  deploy:
+    name: Deploy to ECR and EC2
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Build, tag, and push backend image to Amazon ECR
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: image-editor-backend
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        cd backend
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+    - name: Build, tag, and push frontend image to Amazon ECR
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: image-editor-frontend
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        cd frontend
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+    - name: Get EC2 Instance IDs
+      id: get-instances
+      run: |
+        BACKEND_INSTANCE_ID=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
+                    "Name=instance-state-name,Values=running" \
+          --query "Reservations[0].Instances[0].InstanceId" \
+          --output text)
+        FRONTEND_INSTANCE_ID=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
+                    "Name=instance-state-name,Values=running" \
+          --query "Reservations[0].Instances[0].InstanceId" \
+          --output text)
+        echo "backend_instance_id=$BACKEND_INSTANCE_ID" >> $GITHUB_OUTPUT
+        echo "frontend_instance_id=$FRONTEND_INSTANCE_ID" >> $GITHUB_OUTPUT
+
+    - name: Update Backend EC2 Instance
+      if: steps.get-instances.outputs.backend_instance_id != 'None'
+      env:
+        INSTANCE_ID: ${{ steps.get-instances.outputs.backend_instance_id }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: image-editor-backend
+      run: |
+        # Send commands to update the backend container via SSM
+        aws ssm send-command \
+          --instance-ids "$INSTANCE_ID" \
+          --document-name "AWS-RunShellScript" \
+          --parameters 'commands=[
+            "aws ecr get-login-password --region '${{ env.AWS_REGION }}' | docker login --username AWS --password-stdin '$ECR_REGISTRY'",
+            "docker pull '$ECR_REGISTRY'/'$ECR_REPOSITORY':latest",
+            "docker stop backend || true",
+            "docker rm backend || true",
+            "docker run -d --name backend --restart always -p 8080:8080 '$ECR_REGISTRY'/'$ECR_REPOSITORY':latest",
+            "systemctl restart backend || true"
+          ]' \
+          --output text
+
+    - name: Update Frontend EC2 Instance
+      if: steps.get-instances.outputs.frontend_instance_id != 'None'
+      env:
+        INSTANCE_ID: ${{ steps.get-instances.outputs.frontend_instance_id }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: image-editor-frontend
+      run: |
+        # Get backend private IP for environment variable
+        BACKEND_IP=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
+                    "Name=instance-state-name,Values=running" \
+          --query "Reservations[0].Instances[0].PrivateIpAddress" \
+          --output text)
+        
+        # Send commands to update the frontend container via SSM
+        aws ssm send-command \
+          --instance-ids "$INSTANCE_ID" \
+          --document-name "AWS-RunShellScript" \
+          --parameters 'commands=[
+            "aws ecr get-login-password --region '${{ env.AWS_REGION }}' | docker login --username AWS --password-stdin '$ECR_REGISTRY'",
+            "docker pull '$ECR_REGISTRY'/'$ECR_REPOSITORY':latest",
+            "docker stop frontend || true",
+            "docker rm frontend || true",
+            "docker run -d --name frontend --restart always -p 3000:3000 -e BACKEND_URL=http://'$BACKEND_IP':8080 '$ECR_REGISTRY'/'$ECR_REPOSITORY':latest",
+            "systemctl restart frontend || true"
+          ]' \
+          --output text
+
+    - name: Wait for deployment to complete
+      run: |
+        echo "Waiting for deployments to complete..."
+        sleep 30
+        
+        # Check backend health
+        BACKEND_ID="${{ steps.get-instances.outputs.backend_instance_id }}"
+        if [ "$BACKEND_ID" != "None" ]; then
+          echo "Checking backend instance health..."
+          aws ec2 describe-instance-status --instance-ids "$BACKEND_ID" \
+            --query "InstanceStatuses[0].InstanceStatus.Status" --output text
+        fi
+        
+        # Check frontend health
+        FRONTEND_ID="${{ steps.get-instances.outputs.frontend_instance_id }}"
+        if [ "$FRONTEND_ID" != "None" ]; then
+          echo "Checking frontend instance health..."
+          aws ec2 describe-instance-status --instance-ids "$FRONTEND_ID" \
+            --query "InstanceStatuses[0].InstanceStatus.Status" --output text
+        fi

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,4 +1,9 @@
 name: Deploy to ECR
+# NOTE: This workflow only pushes images to ECR but does not deploy to EC2 instances.
+# For full deployment including EC2 updates, use deploy-to-ec2.yml instead.
+# This workflow is kept for backward compatibility or if you only want to push images
+# without triggering deployments.
+
 
 on:
   push:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,205 @@
+# Deployment Guide for Image Editor Application
+
+## Overview
+
+This document describes the deployment process for the Image Editor application to AWS infrastructure using ECR (Elastic Container Registry) and EC2 instances.
+
+## Current Issues Fixed
+
+The original GitHub Actions workflow (`deploy-to-ecr.yml`) had a critical issue:
+- ❌ **Only pushed images to ECR** but didn't deploy them to EC2 instances
+- ❌ **EC2 instances only pulled images once** during initial boot
+- ❌ **No automatic updates** when new images were pushed
+
+## Solution Implemented
+
+### 1. Enhanced GitHub Actions Workflow
+
+Created a new workflow file: `.github/workflows/deploy-to-ec2.yml`
+
+This workflow:
+- ✅ Builds and pushes Docker images to ECR
+- ✅ Automatically updates running EC2 instances with new images
+- ✅ Uses AWS Systems Manager (SSM) to send deployment commands
+- ✅ Performs health checks after deployment
+
+### 2. Manual Deployment Script
+
+Created a deployment script: `scripts/deploy-to-ec2.sh`
+
+This script can be used for:
+- Manual deployments
+- Troubleshooting
+- Integration with other CI/CD tools
+
+## Prerequisites
+
+### GitHub Secrets Required
+
+Configure these secrets in your GitHub repository:
+- `AWS_ACCESS_KEY_ID`: AWS access key with necessary permissions
+- `AWS_SECRET_ACCESS_KEY`: AWS secret access key
+
+### AWS Permissions Required
+
+The AWS IAM user/role needs permissions for:
+- ECR: Push and pull images
+- EC2: Describe instances
+- SSM: Send commands to EC2 instances
+- ELB: Describe load balancers (optional, for getting ALB URL)
+
+### Terraform Infrastructure
+
+Ensure the Terraform infrastructure is deployed with:
+- ECR repositories: `image-editor-backend` and `image-editor-frontend`
+- EC2 instances with tags:
+  - Backend: `Name=image-editor-backend`
+  - Frontend: `Name=image-editor-frontend`
+- IAM roles with SSM permissions attached to EC2 instances
+
+## Deployment Process
+
+### Automatic Deployment (GitHub Actions)
+
+1. Push code to the `main` branch
+2. GitHub Actions workflow automatically:
+   - Builds Docker images
+   - Pushes to ECR
+   - Updates EC2 instances
+   - Restarts containers with new images
+
+### Manual Deployment
+
+1. Ensure AWS CLI is configured:
+   ```bash
+   aws configure
+   ```
+
+2. Run the deployment script:
+   ```bash
+   ./scripts/deploy-to-ec2.sh
+   ```
+
+3. The script will:
+   - Pull latest images from ECR to EC2 instances
+   - Stop old containers
+   - Start new containers with updated images
+   - Display the application URL
+
+## How It Works
+
+### Image Building and Pushing
+1. Docker images are built from `backend/Dockerfile` and `frontend/Dockerfile`
+2. Images are tagged with both commit SHA and `latest`
+3. Images are pushed to ECR repositories
+
+### EC2 Instance Updates
+1. The workflow/script identifies running EC2 instances by their tags
+2. Uses AWS Systems Manager to send commands to instances
+3. Commands executed on each instance:
+   - Authenticate with ECR
+   - Pull latest Docker image
+   - Stop and remove old container
+   - Start new container with updated image
+   - Configure environment variables (e.g., BACKEND_URL for frontend)
+
+### Container Management
+- Containers are configured with `--restart always` flag
+- Systemd services ensure containers start on boot
+- Health checks verify deployment success
+
+## Monitoring Deployment
+
+### Check Deployment Status
+
+1. **Via AWS Console:**
+   - Go to Systems Manager > Run Command
+   - View command execution status
+
+2. **Via CLI:**
+   ```bash
+   aws ssm list-command-invocations --command-id <command-id>
+   ```
+
+3. **Check Container Status on EC2:**
+   ```bash
+   # Connect to instance via Session Manager
+   aws ssm start-session --target <instance-id>
+   
+   # Check Docker containers
+   docker ps
+   docker logs backend  # or frontend
+   ```
+
+### Access the Application
+
+After successful deployment:
+1. Get the ALB URL from Terraform outputs or AWS Console
+2. Access the application at: `http://<alb-dns-name>`
+
+## Troubleshooting
+
+### Common Issues
+
+1. **SSM Commands Fail:**
+   - Ensure EC2 instances have SSM agent installed and running
+   - Verify IAM role has `AmazonSSMManagedInstanceCore` policy
+
+2. **Docker Pull Fails:**
+   - Check ECR repository permissions
+   - Verify EC2 IAM role has ECR pull permissions
+
+3. **Containers Don't Start:**
+   - Check Docker logs: `docker logs <container-name>`
+   - Verify port availability
+   - Check environment variables
+
+### Debug Commands
+
+```bash
+# Check if instances are running
+aws ec2 describe-instances --filters "Name=tag:Name,Values=image-editor-*"
+
+# Check ECR repositories
+aws ecr describe-repositories --repository-names image-editor-backend image-editor-frontend
+
+# Test SSM connectivity
+aws ssm describe-instance-information --filters "Key=tag:Name,Values=image-editor-*"
+```
+
+## Security Considerations
+
+1. **Secrets Management:**
+   - Use GitHub Secrets for AWS credentials
+   - Consider using AWS IAM roles for GitHub Actions (OIDC)
+
+2. **Network Security:**
+   - EC2 instances are in private subnets
+   - Only ALB is publicly accessible
+   - Security groups restrict traffic appropriately
+
+3. **Image Security:**
+   - ECR scanning is enabled for vulnerability detection
+   - Use specific image tags in production (not just `latest`)
+
+## Future Improvements
+
+1. **Blue-Green Deployment:**
+   - Implement zero-downtime deployments
+   - Use multiple target groups with ALB
+
+2. **Auto-Scaling:**
+   - Add Auto Scaling Groups for EC2 instances
+   - Implement health checks and automatic recovery
+
+3. **Container Orchestration:**
+   - Consider migrating to ECS or EKS for better container management
+   - Implement service discovery and load balancing
+
+4. **Monitoring:**
+   - Add CloudWatch alarms for deployment failures
+   - Implement application performance monitoring
+
+5. **Rollback Capability:**
+   - Tag images with version numbers
+   - Implement automatic rollback on failure

--- a/scripts/deploy-to-ec2.sh
+++ b/scripts/deploy-to-ec2.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# Deploy script for updating EC2 instances with latest Docker images from ECR
+# This script can be run manually or integrated into CI/CD pipelines
+
+set -e
+
+# Configuration
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ECR_REGISTRY="${ECR_REGISTRY}"
+BACKEND_REPO="image-editor-backend"
+FRONTEND_REPO="image-editor-frontend"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    print_error "AWS CLI is not installed. Please install it first."
+    exit 1
+fi
+
+# Get ECR registry if not provided
+if [ -z "$ECR_REGISTRY" ]; then
+    print_status "Getting ECR registry URL..."
+    ECR_REGISTRY=$(aws ecr describe-repositories --repository-names $BACKEND_REPO --region $AWS_REGION --query 'repositories[0].repositoryUri' --output text | sed 's/\/image-editor-backend$//')
+    if [ -z "$ECR_REGISTRY" ]; then
+        print_error "Could not determine ECR registry URL"
+        exit 1
+    fi
+fi
+
+print_status "ECR Registry: $ECR_REGISTRY"
+
+# Function to update an EC2 instance
+update_instance() {
+    local INSTANCE_NAME=$1
+    local CONTAINER_NAME=$2
+    local ECR_REPO=$3
+    local PORT=$4
+    local EXTRA_ENV=$5
+    
+    print_status "Updating $INSTANCE_NAME..."
+    
+    # Get instance ID
+    INSTANCE_ID=$(aws ec2 describe-instances \
+        --filters "Name=tag:Name,Values=$INSTANCE_NAME" \
+                  "Name=instance-state-name,Values=running" \
+        --query "Reservations[0].Instances[0].InstanceId" \
+        --output text \
+        --region $AWS_REGION)
+    
+    if [ "$INSTANCE_ID" == "None" ] || [ -z "$INSTANCE_ID" ]; then
+        print_warning "$INSTANCE_NAME not found or not running. Skipping..."
+        return
+    fi
+    
+    print_status "Found instance: $INSTANCE_ID"
+    
+    # Prepare docker run command
+    DOCKER_RUN_CMD="docker run -d --name $CONTAINER_NAME --restart always -p $PORT:$PORT"
+    if [ ! -z "$EXTRA_ENV" ]; then
+        DOCKER_RUN_CMD="$DOCKER_RUN_CMD $EXTRA_ENV"
+    fi
+    DOCKER_RUN_CMD="$DOCKER_RUN_CMD $ECR_REGISTRY/$ECR_REPO:latest"
+    
+    # Send update commands via SSM
+    print_status "Sending update commands to $INSTANCE_NAME..."
+    COMMAND_ID=$(aws ssm send-command \
+        --instance-ids "$INSTANCE_ID" \
+        --document-name "AWS-RunShellScript" \
+        --parameters "commands=[
+            'echo \"Updating $CONTAINER_NAME container...\"',
+            'aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY',
+            'docker pull $ECR_REGISTRY/$ECR_REPO:latest',
+            'docker stop $CONTAINER_NAME 2>/dev/null || true',
+            'docker rm $CONTAINER_NAME 2>/dev/null || true',
+            '$DOCKER_RUN_CMD',
+            'docker ps | grep $CONTAINER_NAME'
+        ]" \
+        --output text \
+        --query 'Command.CommandId' \
+        --region $AWS_REGION)
+    
+    if [ ! -z "$COMMAND_ID" ]; then
+        print_status "Command sent with ID: $COMMAND_ID"
+        
+        # Wait for command to complete
+        print_status "Waiting for deployment to complete..."
+        sleep 10
+        
+        # Check command status
+        STATUS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$INSTANCE_ID" \
+            --query 'Status' \
+            --output text \
+            --region $AWS_REGION 2>/dev/null || echo "Pending")
+        
+        print_status "Deployment status: $STATUS"
+    else
+        print_error "Failed to send command to $INSTANCE_NAME"
+    fi
+}
+
+# Main deployment process
+print_status "Starting deployment to EC2 instances..."
+
+# Update Backend
+update_instance "image-editor-backend" "backend" "$BACKEND_REPO" "8080" ""
+
+# Get backend private IP for frontend environment variable
+BACKEND_IP=$(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=image-editor-backend" \
+              "Name=instance-state-name,Values=running" \
+    --query "Reservations[0].Instances[0].PrivateIpAddress" \
+    --output text \
+    --region $AWS_REGION)
+
+if [ ! -z "$BACKEND_IP" ] && [ "$BACKEND_IP" != "None" ]; then
+    # Update Frontend with backend URL
+    update_instance "image-editor-frontend" "frontend" "$FRONTEND_REPO" "3000" "-e BACKEND_URL=http://$BACKEND_IP:8080"
+else
+    print_warning "Could not get backend IP. Frontend may not connect properly to backend."
+    update_instance "image-editor-frontend" "frontend" "$FRONTEND_REPO" "3000" ""
+fi
+
+print_status "Deployment process completed!"
+
+# Get ALB URL for accessing the application
+ALB_DNS=$(aws elbv2 describe-load-balancers \
+    --names "image-editor-alb" \
+    --query 'LoadBalancers[0].DNSName' \
+    --output text \
+    --region $AWS_REGION 2>/dev/null)
+
+if [ ! -z "$ALB_DNS" ] && [ "$ALB_DNS" != "None" ]; then
+    print_status "Application should be accessible at: http://$ALB_DNS"
+fi


### PR DESCRIPTION
## Problem
The existing GitHub Actions workflow (`deploy-to-ecr.yml`) only pushes Docker images to ECR but doesn't actually deploy them to the EC2 instances defined in the terraform-demo. The EC2 instances only pull images once during initial boot and have no mechanism to update when new images are available.

## Solution
This PR adds a complete deployment solution:

### 1. New GitHub Actions Workflow (`deploy-to-ec2.yml`)
- Builds and pushes Docker images to ECR (same as before)
- **NEW:** Automatically updates running EC2 instances using AWS Systems Manager (SSM)
- **NEW:** Pulls latest images and restarts containers on EC2 instances
- **NEW:** Performs health checks after deployment

### 2. Manual Deployment Script (`scripts/deploy-to-ec2.sh`)
- Provides a way to manually trigger deployments
- Useful for troubleshooting and integration with other tools
- Includes colored output and error handling

### 3. Comprehensive Documentation (`DEPLOYMENT.md`)
- Explains the deployment process
- Documents prerequisites and permissions
- Includes troubleshooting guide
- Suggests future improvements

### 4. Updated Original Workflow
- Added comments to clarify that `deploy-to-ecr.yml` only pushes to ECR
- Directs users to the new workflow for full deployments

## Key Features
- ✅ Automatic deployment to EC2 on push to main branch
- ✅ Uses AWS SSM for secure command execution (no SSH needed)
- ✅ Maintains container environment variables (e.g., BACKEND_URL)
- ✅ Zero-downtime deployments with container replacement
- ✅ Health checks and status reporting

## Testing
To test this:
1. Ensure AWS credentials are configured in GitHub Secrets
2. Push to main branch or manually run the workflow
3. Verify containers are updated on EC2 instances
4. Check application is accessible via ALB URL

## Required GitHub Secrets
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

The AWS credentials need permissions for ECR, EC2, SSM, and optionally ELB operations.