### PR TITLE
Fix GitHub Actions EC2 deployment - corrected instance tag filters

### DIFF
--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -52,7 +52,7 @@ jobs:
         
         # Get Backend EC2 instance IDs
         BACKEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-backend-*" \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -140,7 +140,7 @@ jobs:
         
         # Get Frontend EC2 instance IDs
         FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -230,7 +230,7 @@ jobs:
         if [[ "${{ github.event.inputs.component }}" == "backend" ]] || [[ "${{ github.event.inputs.component }}" == "both" ]] || [[ "${{ github.event_name }}" == "workflow_run" ]]; then
           echo "Checking backend instances..."
           BACKEND_INSTANCES=$(aws ec2 describe-instances \
-            --filters "Name=tag:Name,Values=image-editor-backend-*" \
+            --filters "Name=tag:Name,Values=image-editor-backend" \
                       "Name=instance-state-name,Values=running" \
             --query "Reservations[].Instances[].[InstanceId,PublicIpAddress,PrivateIpAddress]" \
             --output text)
@@ -241,7 +241,7 @@ jobs:
         if [[ "${{ github.event.inputs.component }}" == "frontend" ]] || [[ "${{ github.event.inputs.component }}" == "both" ]] || [[ "${{ github.event_name }}" == "workflow_run" ]]; then
           echo "Checking frontend instances..."
           FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-            --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+            --filters "Name=tag:Name,Values=image-editor-frontend" \
                       "Name=instance-state-name,Values=running" \
             --query "Reservations[].Instances[].[InstanceId,PublicIpAddress,PrivateIpAddress]" \
             --output text)

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         # Get Backend EC2 instance IDs
         BACKEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-backend-*" \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -96,7 +96,7 @@ jobs:
       run: |
         # Get Frontend EC2 instance IDs
         FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -130,7 +130,7 @@ jobs:
         
         # Check backend instances health
         BACKEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-backend-*" \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -149,7 +149,7 @@ jobs:
         
         # Check frontend instances health
         FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)

--- a/.github/workflows/rolling-deployment.yml
+++ b/.github/workflows/rolling-deployment.yml
@@ -40,7 +40,7 @@ jobs:
         
         # Get all backend instances
         BACKEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-backend-*" \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -125,7 +125,7 @@ jobs:
         
         # Get all frontend instances
         FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -204,7 +204,7 @@ jobs:
         
         # Check backend instances
         BACKEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-backend-*" \
+          --filters "Name=tag:Name,Values=image-editor-backend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)
@@ -220,7 +220,7 @@ jobs:
         
         # Check frontend instances
         FRONTEND_INSTANCES=$(aws ec2 describe-instances \
-          --filters "Name=tag:Name,Values=image-editor-frontend-*" \
+          --filters "Name=tag:Name,Values=image-editor-frontend" \
                     "Name=instance-state-name,Values=running" \
           --query "Reservations[].Instances[].InstanceId" \
           --output text)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,112 @@
+# Deployment Guide
+
+## Prerequisites
+
+Before the GitHub Actions workflows can deploy to EC2 instances, you need to:
+
+1. **Deploy the Terraform Infrastructure**
+   ```bash
+   cd ../terraform-demo/terraform
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+   This will create:
+   - EC2 instances tagged as `image-editor-backend` and `image-editor-frontend`
+   - ECR repositories for Docker images
+   - VPC, subnets, and security groups
+   - IAM roles with SSM and ECR permissions
+   - Application Load Balancer
+
+2. **Set GitHub Secrets**
+   In your GitHub repository settings, add these secrets:
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   
+   These credentials need permissions for:
+   - ECR (push images)
+   - EC2 (describe instances)
+   - SSM (send commands to instances)
+
+## Deployment Workflows
+
+### Automatic Deployment
+The main workflow (`deploy-to-ecr.yml`) automatically:
+1. Builds Docker images on push to main
+2. Pushes images to ECR
+3. Deploys to EC2 instances using SSM
+
+### Manual Deployment
+Use the `deploy-to-ec2.yml` workflow to:
+- Manually trigger deployments from GitHub Actions UI
+- Deploy specific components (backend/frontend/both)
+- Useful for controlled production releases
+
+### Rolling Deployment
+Use the `rolling-deployment.yml` workflow for:
+- Zero-downtime deployments
+- Updates instances one at a time
+- Includes health checks between updates
+
+## Troubleshooting
+
+### "No running backend/frontend instances found"
+This means the EC2 instances haven't been created yet or are not running.
+
+**Solution:**
+1. Check if Terraform has been applied:
+   ```bash
+   cd ../terraform-demo/terraform
+   terraform show
+   ```
+
+2. Verify instances are running:
+   ```bash
+   aws ec2 describe-instances \
+     --filters "Name=tag:Name,Values=image-editor-backend" \
+               "Name=instance-state-name,Values=running" \
+     --query "Reservations[].Instances[].InstanceId"
+   ```
+
+3. If instances exist but are stopped, start them:
+   ```bash
+   aws ec2 start-instances --instance-ids <instance-id>
+   ```
+
+### SSM Command Failed
+If SSM commands fail, check:
+1. Instance has SSM agent installed and running
+2. Instance has proper IAM role attached
+3. VPC endpoints are configured for SSM (in private subnets)
+
+### Docker Pull Failed
+If Docker can't pull from ECR:
+1. Check ECR repositories exist
+2. Verify instance IAM role has ECR permissions
+3. Check VPC endpoints for ECR are configured
+
+## Architecture Overview
+
+```
+GitHub Actions
+    ↓
+Build & Push to ECR
+    ↓
+SSM Send Command
+    ↓
+EC2 Instances (Private Subnet)
+    ↓
+Pull from ECR & Restart Services
+    ↓
+Application Load Balancer (Public)
+    ↓
+Users
+```
+
+## Instance Tags
+
+The workflows identify EC2 instances by their Name tags:
+- Backend: `Name=image-editor-backend`
+- Frontend: `Name=image-editor-frontend`
+
+These tags are set by Terraform during instance creation.


### PR DESCRIPTION
## Problem Identified
The GitHub Actions workflow was failing with "No running backend instances found" because it was looking for instances with incorrect tag patterns.

## Root Cause
- Workflow was searching for instances with tags like `image-editor-backend-*` (with wildcard)
- Actual EC2 instances are tagged exactly as `image-editor-backend` and `image-editor-frontend` (no suffix)

## Solution
This PR fixes the EC2 instance tag filters in all workflows to match the actual tags created by Terraform.

### Changes Made:

1. **Fixed tag filters in all workflows**:
   - Changed from `image-editor-backend-*` to `image-editor-backend`
   - Changed from `image-editor-frontend-*` to `image-editor-frontend`

2. **Added deployment documentation** (`docs/DEPLOYMENT.md`):
   - Prerequisites and setup instructions
   - Troubleshooting guide
   - Architecture overview
   - Clear explanation of the deployment process

### Files Modified:
- `.github/workflows/deploy-to-ecr.yml` - Fixed instance tag filters
- `.github/workflows/deploy-to-ec2.yml` - Fixed instance tag filters  
- `.github/workflows/rolling-deployment.yml` - Fixed instance tag filters
- `docs/DEPLOYMENT.md` - New comprehensive deployment guide

### Important Note:
**Before these workflows can work, you need to:**
1. Deploy the Terraform infrastructure (`cd ../terraform-demo/terraform && terraform apply`)
2. Ensure GitHub secrets are configured (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)

### Testing:
After merging and ensuring Terraform infrastructure is deployed:
1. Push to main branch to trigger automatic deployment
2. Or manually trigger deployment via Actions UI
3. Verify instances are updated by checking SSM command history

This fix ensures the workflows can correctly identify and deploy to the EC2 instances created by Terraform.